### PR TITLE
Allowing Calling transcribe() from Python

### DIFF
--- a/infer/__main__.py
+++ b/infer/__main__.py
@@ -15,21 +15,30 @@ from utils import config
 DEVICE_DEFAULT = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 SV_SAMPLER = SVSampler()
 
-
-def main(args):
-    path_model = args.path_model or config.path.apc
-    device = torch.device(args.device) if args.device else DEVICE_DEFAULT
+# Transcription function
+def transcribe(src, output_path, style="level2", path_model=None, device=None):
+    """Transcribe the input WAV or YouTube URL to a MIDI file.
+    
+    Args:
+        src (str): Path to the input WAV file or YouTube URL.
+        output_path (str): Path to save the output MIDI file.
+        style (str): Cover style. Valid values are 'level1', 'level2', and 'level3'.
+        path_model (str, optional): Path to the model. Defaults to config path.
+        device (torch.device, optional): Device to run the model on. Defaults to cuda if available.
+    """
+    path_model = path_model or config.path.apc
+    device = torch.device(device) if device else DEVICE_DEFAULT
     pipeline = Pipeline(path_model, device)
 
-    src = args.input
     if src.startswith("https://"):
         src = download(src)
 
-    sv = SV_SAMPLER.sample(params=args.style)
-    pipeline.wav2midi(src, args.output, sv, silent=False)
+    sv = SV_SAMPLER.sample(params=style)
+    pipeline.wav2midi(src, output_path, sv, silent=False)
 
 
 def download(url):
+    """Download audio from YouTube and return the path to the WAV file."""
     from yt_dlp import YoutubeDL
     ydl_opts = {
         "outtmpl": "_audio.%(ext)s",
@@ -46,6 +55,17 @@ def download(url):
     with YoutubeDL(ydl_opts) as ydl:
         ydl.download([url])
     return "_audio.wav"
+
+
+# Main function to handle argument parsing
+def main(args):
+    transcribe(
+        src=args.input,
+        output_path=args.output,
+        style=args.style,
+        path_model=args.path_model,
+        device=args.device,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR enables the functionality to call the `transcribe()` method directly from Python. Users can now transcribe audio files easily within their Python applications, simplifying the integration process.